### PR TITLE
Add cleanly numeric and phone keyboards

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/keyboard/services/SimpleKeyboardIME.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/keyboard/services/SimpleKeyboardIME.kt
@@ -26,6 +26,8 @@ class SimpleKeyboardIME : InputMethodService(), MyKeyboardView.OnKeyboardActionL
     private val KEYBOARD_LETTERS = 0
     private val KEYBOARD_SYMBOLS = 1
     private val KEYBOARD_SYMBOLS_SHIFT = 2
+    private val KEYBOARD_NUMBERS = 3
+    private val KEYBOARD_PHONE = 4
 
     private var keyboard: MyKeyboard? = null
     private var keyboardView: MyKeyboardView? = null
@@ -217,7 +219,15 @@ class SimpleKeyboardIME : InputMethodService(), MyKeyboardView.OnKeyboardActionL
 
     private fun getKeyBoard(): MyKeyboard {
         val keyboardXml = when (inputTypeClass) {
-            TYPE_CLASS_NUMBER, TYPE_CLASS_DATETIME, TYPE_CLASS_PHONE -> {
+            TYPE_CLASS_NUMBER -> {
+                keyboardMode = KEYBOARD_NUMBERS
+                R.xml.keys_numbers
+            }
+            TYPE_CLASS_PHONE -> {
+                keyboardMode = KEYBOARD_PHONE
+                R.xml.keys_phone
+            }
+            TYPE_CLASS_DATETIME -> {
                 keyboardMode = KEYBOARD_SYMBOLS
                 R.xml.keys_symbols
             }

--- a/app/src/main/res/xml/keys_numbers.xml
+++ b/app/src/main/res/xml/keys_numbers.xml
@@ -46,8 +46,8 @@
             app:keyLabel="9"
             app:keyWidth="25%p" />
         <Key
-            app:keyLabel="abc"
-            app:code="-2"
+            app:keyLabel="␣"
+            app:code="32"
             app:keyEdgeFlags="right"
             app:keyWidth="25%p" />
     </Row>

--- a/app/src/main/res/xml/keys_numbers.xml
+++ b/app/src/main/res/xml/keys_numbers.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto">
+    <Row>
+        <Key
+            app:keyLabel="1"
+            app:keyEdgeFlags="left"
+            app:keyWidth="25%p" />
+        <Key
+            app:keyLabel="2"
+            app:keyWidth="25%p" />
+        <Key
+            app:keyLabel="3"
+            app:keyWidth="25%p" />
+        <Key
+            app:keyIcon="@drawable/ic_clear_vector"
+            app:code="-5"
+            app:isRepeatable="true"
+            app:keyEdgeFlags="right"
+            app:keyWidth="25%p" />
+    </Row>
+    <Row>
+        <Key
+            app:keyLabel="4"
+            app:keyEdgeFlags="left"
+            app:keyWidth="25%p" />
+        <Key
+            app:keyLabel="5"
+            app:keyWidth="25%p" />
+        <Key
+            app:keyLabel="6"
+            app:keyWidth="25%p" />
+        <Key
+            app:keyEdgeFlags="right"
+            app:keyWidth="25%p" />
+    </Row>
+    <Row>
+        <Key
+            app:keyLabel="7"
+            app:keyEdgeFlags="left"
+            app:keyWidth="25%p" />
+        <Key
+            app:keyLabel="8"
+            app:keyWidth="25%p" />
+        <Key
+            app:keyLabel="9"
+            app:keyWidth="25%p" />
+        <Key
+            app:keyLabel="abc"
+            app:code="-2"
+            app:keyEdgeFlags="right"
+            app:keyWidth="25%p" />
+    </Row>
+    <Row>
+        <Key
+            app:keyLabel=","
+            app:keyEdgeFlags="left"
+            app:keyWidth="25%p" />
+        <Key
+            app:keyLabel="0"
+            app:keyWidth="25%p" />
+        <Key
+            app:keyLabel="."
+            app:keyWidth="25%p" />
+        <Key
+            app:keyIcon="@drawable/ic_enter_vector"
+            app:code="-4"
+            app:keyEdgeFlags="right"
+            app:keyWidth="25%p" />
+    </Row>
+</Keyboard>

--- a/app/src/main/res/xml/keys_numbers.xml
+++ b/app/src/main/res/xml/keys_numbers.xml
@@ -30,6 +30,7 @@
             app:keyLabel="6"
             app:keyWidth="25%p" />
         <Key
+            app:keyLabel="-"
             app:keyEdgeFlags="right"
             app:keyWidth="25%p" />
     </Row>

--- a/app/src/main/res/xml/keys_phone.xml
+++ b/app/src/main/res/xml/keys_phone.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Keyboard xmlns:app="http://schemas.android.com/apk/res-auto">
+    <Row>
+        <Key
+            app:keyLabel="1"
+            app:keyEdgeFlags="left"
+            app:keyWidth="25%p" />
+        <Key
+            app:keyLabel="2"
+            app:keyWidth="25%p" />
+        <Key
+            app:keyLabel="3"
+            app:keyWidth="25%p" />
+        <Key
+            app:keyIcon="@drawable/ic_clear_vector"
+            app:code="-5"
+            app:isRepeatable="true"
+            app:keyEdgeFlags="right"
+            app:keyWidth="25%p" />
+    </Row>
+    <Row>
+        <Key
+            app:keyLabel="4"
+            app:keyEdgeFlags="left"
+            app:keyWidth="25%p" />
+        <Key
+            app:keyLabel="5"
+            app:keyWidth="25%p" />
+        <Key
+            app:keyLabel="6"
+            app:keyWidth="25%p" />
+        <Key
+            app:keyEdgeFlags="right"
+            app:keyWidth="25%p" />
+    </Row>
+    <Row>
+        <Key
+            app:keyLabel="7"
+            app:keyEdgeFlags="left"
+            app:keyWidth="25%p" />
+        <Key
+            app:keyLabel="8"
+            app:keyWidth="25%p" />
+        <Key
+            app:keyLabel="9"
+            app:keyWidth="25%p" />
+        <Key
+            app:keyLabel="abc"
+            app:code="-2"
+            app:keyEdgeFlags="right"
+            app:keyWidth="25%p" />
+    </Row>
+    <Row>
+        <Key
+            app:keyLabel="*"
+            app:keyEdgeFlags="left"
+            app:keyWidth="25%p" />
+        <Key
+            app:keyLabel="0"
+            app:topSmallNumber="+"
+            app:popupKeyboard="@xml/keyboard_popup_template"
+            app:popupCharacters="+-,."
+            app:keyWidth="25%p" />
+        <Key
+            app:keyLabel="#"
+            app:keyWidth="25%p" />
+        <Key
+            app:keyIcon="@drawable/ic_enter_vector"
+            app:code="-4"
+            app:keyEdgeFlags="right"
+            app:keyWidth="25%p" />
+    </Row>
+</Keyboard>


### PR DESCRIPTION
There are some cases, when only or mostly numeric data should be typed (eg. adding a phone number to contacts). It is uneasy to find the correct buttons withing the >30 using the current _symbols_ keyboard.

This pull request adds a cleanly numeric and a phone keyboard that pop up by default for numeric or tel input fields respectively. Switch-back to normal keyboard is available with a dedicated key. I found it useless to add other methods for getting these keyboards. Clicking out if a text box and giving back the focus is the fastest and most intuitive way I suppose.

Closes #93