### PR TITLE
Direct boot aware fixes

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/keyboard/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/keyboard/extensions/Context.kt
@@ -1,5 +1,6 @@
 package com.simplemobiletools.keyboard.extensions
 
+import android.app.KeyguardManager
 import android.content.ClipboardManager
 import android.content.Context
 import android.graphics.Color
@@ -32,6 +33,12 @@ val Context.isDeviceInDirectBootMode: Boolean
     get() {
         val userManager = getSystemService(Context.USER_SERVICE) as UserManager
         return isNougatPlus() && !userManager.isUserUnlocked
+    }
+
+val Context.isDeviceLocked: Boolean
+    get() {
+        val keyguardManager = getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
+        return keyguardManager.isDeviceLocked || isDeviceInDirectBootMode
     }
 
 val Context.clipsDB: ClipsDao

--- a/app/src/main/kotlin/com/simplemobiletools/keyboard/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/keyboard/extensions/Context.kt
@@ -38,7 +38,7 @@ val Context.isDeviceInDirectBootMode: Boolean
 val Context.isDeviceLocked: Boolean
     get() {
         val keyguardManager = getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
-        return keyguardManager.isDeviceLocked || isDeviceInDirectBootMode
+        return keyguardManager.isDeviceLocked || keyguardManager.isKeyguardLocked || isDeviceInDirectBootMode
     }
 
 val Context.clipsDB: ClipsDao

--- a/app/src/main/kotlin/com/simplemobiletools/keyboard/helpers/Config.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/keyboard/helpers/Config.kt
@@ -2,7 +2,7 @@ package com.simplemobiletools.keyboard.helpers
 
 import android.content.Context
 import com.simplemobiletools.commons.helpers.BaseConfig
-import com.simplemobiletools.keyboard.extensions.isDeviceInDirectBootMode
+import com.simplemobiletools.keyboard.extensions.isDeviceLocked
 import com.simplemobiletools.keyboard.extensions.safeStorageContext
 import java.util.Locale
 
@@ -44,10 +44,10 @@ class Config(context: Context) : BaseConfig(context) {
         set(showClipboardContent) = prefs.edit().putBoolean(SHOW_CLIPBOARD_CONTENT, showClipboardContent).apply()
 
     var showNumbersRow: Boolean
-        get() = if (!context.isDeviceInDirectBootMode) {
-            prefs.getBoolean(SHOW_NUMBERS_ROW, false)
-        } else {
+        get() = if (context.isDeviceLocked) {
             true
+        } else {
+            prefs.getBoolean(SHOW_NUMBERS_ROW, false)
         }
         set(showNumbersRow) = prefs.edit().putBoolean(SHOW_NUMBERS_ROW, showNumbersRow).apply()
 

--- a/app/src/main/kotlin/com/simplemobiletools/keyboard/services/SimpleKeyboardIME.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/keyboard/services/SimpleKeyboardIME.kt
@@ -46,8 +46,8 @@ class SimpleKeyboardIME : InputMethodService(), OnKeyboardActionListener, Shared
     override fun onCreateInputView(): View {
         val keyboardHolder = layoutInflater.inflate(R.layout.keyboard_view_keyboard, null)
         keyboardView = keyboardHolder.keyboard_view as MyKeyboardView
-        keyboardView!!.setKeyboard(keyboard!!)
         keyboardView!!.setKeyboardHolder(keyboardHolder.keyboard_holder)
+        keyboardView!!.setKeyboard(keyboard!!)
         keyboardView!!.setEditorInfo(currentInputEditorInfo)
         keyboardView!!.mOnKeyboardActionListener = this
         return keyboardHolder!!

--- a/app/src/main/kotlin/com/simplemobiletools/keyboard/views/MyKeyboardView.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/keyboard/views/MyKeyboardView.kt
@@ -269,6 +269,7 @@ class MyKeyboardView @JvmOverloads constructor(context: Context, attrs: Attribut
         invalidateAllKeys()
         computeProximityThreshold(keyboard)
         mMiniKeyboardCache.clear()
+        mToolbarHolder?.beInvisibleIf(context.isDeviceLocked)
 
         accessHelper = AccessHelper(this, mKeyboard?.mKeys.orEmpty())
         ViewCompat.setAccessibilityDelegate(this, accessHelper)

--- a/app/src/main/kotlin/com/simplemobiletools/keyboard/views/MyKeyboardView.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/keyboard/views/MyKeyboardView.kt
@@ -400,7 +400,7 @@ class MyKeyboardView @JvmOverloads constructor(context: Context, attrs: Attribut
             pinned_clipboard_items.applyColorFilter(mTextColor)
             clipboard_clear.applyColorFilter(mTextColor)
 
-            toolbar_holder.beInvisibleIf(context.isDeviceInDirectBootMode)
+            beInvisibleIf(context.isDeviceLocked)
         }
 
         mClipboardManagerHolder?.apply {


### PR DESCRIPTION
Made some improvements.

Toolbar was being visible on a lock screen (not after reboot, just after the regular device lock) - **Fixed in first commit**

Toolbar visibility problem could be reproduced next way (**Fixed in second commit**):
1. Start typing something in a simple keyboard app field, for example
2. Lock the screen immediately
3. Unlock the device (should be with password) and you will see that toolbar is still invisible. You need to close keyboard and open again in order to update toolbar visibility.