### PR TITLE
Ensure no multiple capital letters appear without using delay

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/keyboard/services/SimpleKeyboardIME.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/keyboard/services/SimpleKeyboardIME.kt
@@ -260,14 +260,13 @@ class SimpleKeyboardIME : InputMethodService(), OnKeyboardActionListener, Shared
                                     }
                                 }
                                 inputConnection.commitText(codeChar.toString(), 1)
+                                updateShiftKeyState()
                             }
                         }
 
                         else -> {
                             inputConnection.commitText(codeChar.toString(), 1)
-                            if (originalText == null) {
-                                updateShiftKeyState()
-                            }
+                            updateShiftKeyState()
                         }
                     }
                 }

--- a/app/src/main/kotlin/com/simplemobiletools/keyboard/views/MyKeyboardView.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/keyboard/views/MyKeyboardView.kt
@@ -1218,14 +1218,12 @@ class MyKeyboardView @JvmOverloads constructor(context: Context, attrs: Attribut
                 val secondKeyIndex = getPressedKeyIndex(newPointerX, newPointerY)
                 showPreview(secondKeyIndex)
 
-                mHandler!!.postDelayed({
-                    detectAndSendKey(secondKeyIndex, newPointerX, newPointerY, eventTime)
+                detectAndSendKey(secondKeyIndex, newPointerX, newPointerY, eventTime)
 
-                    val secondKeyCode = mKeys.getOrNull(secondKeyIndex)?.code
-                    if (secondKeyCode != null) {
-                        mOnKeyboardActionListener!!.onPress(secondKeyCode)
-                    }
-                }, REPEAT_INTERVAL.toLong())
+                val secondKeyCode = mKeys.getOrNull(secondKeyIndex)?.code
+                if (secondKeyCode != null) {
+                    mOnKeyboardActionListener!!.onPress(secondKeyCode)
+                }
 
                 showPreview(NOT_A_KEY)
                 invalidateKey(mCurrentKey)


### PR DESCRIPTION
This fixes the issue of capitalizing two letters when SHIFT is active, but it does not use delay. It instead always updates shift state right right after a key press, to ensure it is in the right state as soon as next key is typed. This removes the delay added in #210.