### PR TITLE
Fix some characters stuck. Fix #251

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/keyboard/views/MyKeyboardView.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/keyboard/views/MyKeyboardView.kt
@@ -1012,37 +1012,6 @@ class MyKeyboardView @JvmOverloads constructor(context: Context, attrs: Attribut
                         mMiniKeyboard = miniKeyboardView
                     }
 
-                    mMiniKeyboard!!.mOnKeyboardActionListener = object : OnKeyboardActionListener {
-                        override fun onKey(code: Int) {
-                            mOnKeyboardActionListener!!.onKey(code)
-                            dismissPopupKeyboard()
-                        }
-
-                        override fun onPress(primaryCode: Int) {
-                            mOnKeyboardActionListener!!.onPress(primaryCode)
-                        }
-
-                        override fun onActionUp() {
-                            mOnKeyboardActionListener!!.onActionUp()
-                        }
-
-                        override fun moveCursorLeft() {
-                            mOnKeyboardActionListener!!.moveCursorLeft()
-                        }
-
-                        override fun moveCursorRight() {
-                            mOnKeyboardActionListener!!.moveCursorRight()
-                        }
-
-                        override fun onText(text: String) {
-                            mOnKeyboardActionListener!!.onText(text)
-                        }
-
-                        override fun reloadKeyboard() {
-                            mOnKeyboardActionListener!!.reloadKeyboard()
-                        }
-                    }
-
                     val keyboard = if (popupKey.popupCharacters != null) {
                         MyKeyboard(context, popupKeyboardId, popupKey.popupCharacters!!, popupKey.width)
                     } else {
@@ -1056,7 +1025,9 @@ class MyKeyboardView @JvmOverloads constructor(context: Context, attrs: Attribut
                     )
                     mMiniKeyboardCache[popupKey] = mMiniKeyboardContainer
                 } else {
-                    mMiniKeyboard = keyboardPopupBinding!!.miniKeyboardView
+                    //Using 'miniKeyboardView' from cache
+                    mMiniKeyboard = mMiniKeyboardCache[popupKey]?.let(KeyboardPopupKeyboardBinding::bind)?.miniKeyboardView
+                        ?: keyboardPopupBinding!!.miniKeyboardView
                 }
 
                 getLocationInWindow(mCoordinates)

--- a/app/src/main/kotlin/com/simplemobiletools/keyboard/views/MyKeyboardView.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/keyboard/views/MyKeyboardView.kt
@@ -1025,9 +1025,7 @@ class MyKeyboardView @JvmOverloads constructor(context: Context, attrs: Attribut
                     )
                     mMiniKeyboardCache[popupKey] = mMiniKeyboardContainer
                 } else {
-                    //Using 'miniKeyboardView' from cache
                     mMiniKeyboard = mMiniKeyboardCache[popupKey]?.let(KeyboardPopupKeyboardBinding::bind)?.miniKeyboardView
-                        ?: keyboardPopupBinding!!.miniKeyboardView
                 }
 
                 getLocationInWindow(mCoordinates)


### PR DESCRIPTION
Fix #251 
Fixed issue with caching for mini keyboard views: Getting 'miniKeyboardView' from 'mMiniKeyboardCache' and not from the previously shown layout. It's not related to a specific language.

+ removed mMiniKeyboard!!.mOnKeyboardActionListener is not needed in MyKeyboardView.onLongPress() func. Originally defined in SimpleKeyboardIME class.

How it works now https://youtube.com/shorts/GX2mhKSx910