### PR TITLE
Do not trim text in clipboard

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/keyboard/dialogs/AddOrEditClipDialog.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/keyboard/dialogs/AddOrEditClipDialog.kt
@@ -24,7 +24,7 @@ class AddOrEditClipDialog(val activity: BaseSimpleActivity, val originalClip: Cl
                 activity.setupDialogStuff(binding.root, this) { alertDialog ->
                     alertDialog.showKeyboard(binding.addClipValue)
                     alertDialog.getButton(AlertDialog.BUTTON_POSITIVE).setOnClickListener {
-                        val clipValue = binding.addClipValue.value
+                        val clipValue = binding.addClipValue.text.toString()
                         if (clipValue.isEmpty()) {
                             activity.toast(R.string.value_cannot_be_empty)
                             return@setOnClickListener

--- a/app/src/main/kotlin/com/simplemobiletools/keyboard/extensions/Context.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/keyboard/extensions/Context.kt
@@ -47,7 +47,7 @@ val Context.clipsDB: ClipsDao
 
 fun Context.getCurrentClip(): String? {
     val clipboardManager = (getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager)
-    return clipboardManager.primaryClip?.getItemAt(0)?.text?.trim()?.toString()
+    return clipboardManager.primaryClip?.getItemAt(0)?.text?.toString()
 }
 
 fun Context.getStrokeColor(): Int {

--- a/app/src/main/kotlin/com/simplemobiletools/keyboard/helpers/ClipsHelper.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/keyboard/helpers/ClipsHelper.kt
@@ -8,7 +8,6 @@ class ClipsHelper(val context: Context) {
 
     // make sure clips have unique values
     fun insertClip(clip: Clip): Long {
-        clip.value = clip.value.trim()
         return if (context.clipsDB.getClipWithValue(clip.value) == null) {
             context.clipsDB.insertOrUpdate(clip)
         } else {


### PR DESCRIPTION
Fix #244

Changes:
- Don't trim the text when getting from a clipboard - ```Context.getCurrentClip()```
- Don't trim  the text when inserting/updating to the local database -  ```ClipsHelper.kt```
- Don't trim the text when adding/editing via 'Manage clipboard items' - ```AddOrEditClipDialog.kt```

In ```AddOrEditClipsDialog``` line 27 the text was trimmed by EditText extension from Simple-Commons. Changed locally.

How it works now https://youtube.com/shorts/h0Xp_tx8zHc