### PR TITLE
Add "/" to 'phone' keyboard as a new key shown at long pressing zero

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/keyboard/views/MyKeyboardView.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/keyboard/views/MyKeyboardView.kt
@@ -1725,9 +1725,10 @@ class MyKeyboardView @JvmOverloads constructor(context: Context, attrs: Attribut
     private fun MyKeyboard.Key.calcKeyWidth(containerWidth: Int): Int {
         val popupKeyCount = this.popupCharacters!!.length
 
-        return if (popupKeyCount > containerWidth / this.width)
+        return if (popupKeyCount > containerWidth / this.width) {
             containerWidth / popupKeyCount
-        else
+        } else {
             this.width
+        }
     }
 }

--- a/app/src/main/res/xml/keys_phone.xml
+++ b/app/src/main/res/xml/keys_phone.xml
@@ -59,7 +59,7 @@
         <Key
             app:keyLabel="0"
             app:keyWidth="25%p"
-            app:popupCharacters="+-,."
+            app:popupCharacters="-+,./"
             app:popupKeyboard="@xml/keyboard_popup_template"
             app:topSmallNumber="+" />
         <Key


### PR DESCRIPTION
Fix #239 
App version 5.4.8

**Changes:** 

* Added a new key "/" right after the dot for 'phone' keyboard.
* Added a way to define the popup key width on the fly [MyKeyboardView.class line 1011]. The existing implementation didn't allow to add more than 4 popup keys to a numeric keyboard cause of width is equal to the main key width.
* Tested all other keyboard types to make sure it works as before.

### Before:

![Screenshot_20231012-230313](https://github.com/SimpleMobileTools/Simple-Keyboard/assets/5750211/e59787e1-68cf-4f36-86da-4cb16280022f)

### After

![Screenshot_20231012-230208](https://github.com/SimpleMobileTools/Simple-Keyboard/assets/5750211/68050c35-cc37-4a10-8531-21a22e5ba40d)



