### PR TITLE
Autofil crash fix#248

### DIFF
--- a/app/src/main/kotlin/com/simplemobiletools/keyboard/services/SimpleKeyboardIME.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/keyboard/services/SimpleKeyboardIME.kt
@@ -441,7 +441,7 @@ class SimpleKeyboardIME : InputMethodService(), OnKeyboardActionListener, Shared
 
         val chipStyle =
             ViewStyle.Builder()
-                //Don't use Icon.createWithBitmap(), it crashes the app. Issue https://github.com/SimpleMobileTools/Simple-Keyboard/issues/248
+                // don't use Icon.createWithBitmap(), it crashes the app. Issue https://github.com/SimpleMobileTools/Simple-Keyboard/issues/248
                 .setBackground(chipBackgroundIcon)
                 .setPadding(horizontalPadding, verticalPadding, horizontalPadding, verticalPadding)
                 .build()

--- a/app/src/main/kotlin/com/simplemobiletools/keyboard/views/MyKeyboardView.kt
+++ b/app/src/main/kotlin/com/simplemobiletools/keyboard/views/MyKeyboardView.kt
@@ -598,7 +598,7 @@ class MyKeyboardView @JvmOverloads constructor(context: Context, attrs: Attribut
                     label, (key.width / 2).toFloat(), key.height / 2 + (paint.textSize - paint.descent()) / 2, paint
                 )
 
-                if (key.topSmallNumber.isNotEmpty() && !context.config.showNumbersRow) {
+                if (key.topSmallNumber.isNotEmpty() && !(context.config.showNumbersRow && Regex("\\d").matches(key.topSmallNumber))) {
                     canvas.drawText(key.topSmallNumber, key.width - mTopSmallNumberMarginWidth, mTopSmallNumberMarginHeight, smallLetterPaint)
                 }
 


### PR DESCRIPTION
App version 5.4.8

Changes: 
* Autofill crash fix #248  . Tested with Bitwarden https://youtube.com/shorts/wuAOzRYeXEA 
  The issue was in Chip style for autofill suggestions: Icon.createWithBitmap() leads to crashes
  
* Fix for top small special symbols for numeric keyboard. It wasn't displayed if the setting "Show numbers on a separate row" was turned ON. How it works now https://youtube.com/shorts/LixX3QMnmZE